### PR TITLE
extract fs dependency

### DIFF
--- a/lib/nodejs/buffer.js
+++ b/lib/nodejs/buffer.js
@@ -1,0 +1,20 @@
+function toArrayBuffer(buffer) {
+    /*
+     * took this function from
+     * http://stackoverflow.com/questions/8609289/convert-a-binary-nodejs-buffer-to-javascript-arraybuffer
+     */
+    var ab = new ArrayBuffer(buffer.length);
+    var view = new Uint8Array(ab);
+    for (var i = 0; i < buffer.length; ++i) {
+        view[i] = buffer[i];
+    }
+    return ab;
+}
+
+function readPBFElementFromBuffer(buffer, pbfDecode, callback){
+    return callback(null, pbfDecode(toArrayBuffer(buffer)));
+}
+
+module.exports = {
+    readPBFElementFromBuffer: readPBFElementFromBuffer
+};

--- a/lib/nodejs/fsReader.js
+++ b/lib/nodejs/fsReader.js
@@ -1,0 +1,60 @@
+var fs = require('fs');
+var buf = require('./buffer.js');
+
+function bytesReadFail(callback, expectedBytes, readBytes){
+    return callback(new Error('Expected ' + expectedBytes + ' bytes but got ' + readBytes));
+}
+
+function readBlobHeaderSize(fd, position, size, callback){
+    var buffer;
+
+    buffer = new Buffer(size);
+
+    fs.read(fd, buffer, 0, size, position, function(err, bytesRead, buffer){
+        if(bytesRead !== size){
+            return bytesReadFail(callback, size, bytesRead);
+        }
+
+        return callback(null, buffer.readInt32BE(0));
+    });
+}
+
+function readPBFElement(fd, position, size, pbfDecode, callback){
+    var buffer;
+
+    if(size > 32 * 1024 * 1024){
+        return callback(new Error('PBF element too big: ' + size + ' bytes'));
+    }
+
+    buffer = new Buffer(size);
+
+    fs.read(fd, buffer, 0, size, position, function(err, bytesRead, buffer){
+        if(bytesRead !== size){
+            return bytesReadFail(callback, size, bytesRead);
+        }
+
+        return buf.readPBFElementFromBuffer(buffer, pbfDecode, callback);
+    });
+}
+
+function getFileSize(fd, callback){
+    fs.fstat(fd, function(err, fdStatus){
+        return callback(err, fdStatus.size);
+    });
+}
+
+function open(opts, callback){
+    fs.open(opts.filePath, 'r', callback);
+}
+
+function close(fd, callback){
+    return fs.close(fd, callback);
+}
+
+module.exports = {
+    readBlobHeaderSize: readBlobHeaderSize,
+    readPBFElement: readPBFElement,
+    getFileSize: getFileSize,
+    open: open,
+    close: close
+};

--- a/lib/pbfParser.js
+++ b/lib/pbfParser.js
@@ -9,9 +9,11 @@
  */
 
 var protoBuf = require("protobufjs");
-var fs = require('fs');
 var zlib = require('zlib');
 var path = require('path');
+
+var buf = require('./nodejs/buffer.js');
+var reader = require('./nodejs/fsReader.js');
 
 var getProtoPath = function(){
     var libDirectoryPath = path.dirname(module.filename);
@@ -26,67 +28,14 @@ var getProtoPath = function(){
 var fileFormat = protoBuf.protoFromFile(getProtoPath('fileformat.proto')).build('OSMPBF');
 var blockFormat = protoBuf.protoFromFile(getProtoPath('osmformat.proto')).build('OSMPBF');
 
-function toArrayBuffer(buffer) {
-    /*
-     * took this function from
-     * http://stackoverflow.com/questions/8609289/convert-a-binary-nodejs-buffer-to-javascript-arraybuffer
-     */
-    var ab = new ArrayBuffer(buffer.length);
-    var view = new Uint8Array(ab);
-    for (var i = 0; i < buffer.length; ++i) {
-        view[i] = buffer[i];
-    }
-    return ab;
-}
-
 var BLOB_HEADER_SIZE_SIZE = 4;
 
-function bytesReadFail(callback, expectedBytes, readBytes){
-    return callback(new Error('Expected ' + expectedBytes + ' bytes but got ' + readBytes));
-}
-
-function readBlobHeaderSize(fd, position, callback){
-    var buffer;
-
-    buffer = new Buffer(BLOB_HEADER_SIZE_SIZE);
-
-    fs.read(fd, buffer, 0, BLOB_HEADER_SIZE_SIZE, position, function(err, bytesRead, buffer){
-        if(bytesRead !== BLOB_HEADER_SIZE_SIZE){
-            return bytesReadFail(callback, BLOB_HEADER_SIZE_SIZE, bytesRead);
-        }
-
-        return callback(null, buffer.readInt32BE(0));
-    });
-}
-
-function readPBFElementFromBuffer(buffer, pbfDecode, callback){
-    return callback(null, pbfDecode(toArrayBuffer(buffer)));
-}
-
-function readPBFElement(fd, position, size, pbfDecode, callback){
-    var buffer;
-
-    if(size > 32 * 1024 * 1024){
-        return callback(new Error('PBF element too big: ' + size + ' bytes'));
-    }
-
-    buffer = new Buffer(size);
-
-    fs.read(fd, buffer, 0, size, position, function(err, bytesRead, buffer){
-        if(bytesRead !== size){
-            return bytesReadFail(callback, size, bytesRead);
-        }
-
-        return readPBFElementFromBuffer(buffer, pbfDecode, callback);
-    });
-}
-
 function readBlobHeaderContent(fd, position, size, callback){
-    return readPBFElement(fd, position, size, fileFormat.BlobHeader.decode, callback);
+    return reader.readPBFElement(fd, position, size, fileFormat.BlobHeader.decode, callback);
 }
 
 function readFileBlock(fd, position, callback){
-    readBlobHeaderSize(fd, position, function(err, blobHeaderSize){
+    reader.readBlobHeaderSize(fd, position, BLOB_HEADER_SIZE_SIZE, function(err, blobHeaderSize){
         if(err){
             return callback(err);
         }
@@ -108,10 +57,9 @@ function readFileBlock(fd, position, callback){
 }
 
 function readFileBlocks(fd, callback){
-    fs.fstat(fd, function(err, fdStatus){
-        var position, fileSize, fileBlocks;
+    reader.getFileSize(fd, function(err, fileSize){
+        var position, fileBlocks;
 
-        fileSize = fdStatus.size;
         position = 0;
         fileBlocks = [];
 
@@ -416,7 +364,7 @@ function createFileParser(fd, callback){
         }
 
         function readBlob(fileBlock, callback){
-            return readPBFElement(fd, fileBlock.blobHeader.position, fileBlock.blobHeader.datasize, fileFormat.Blob.decode, callback);
+            return reader.readPBFElement(fd, fileBlock.blobHeader.position, fileBlock.blobHeader.datasize, fileFormat.Blob.decode, callback);
         }
 
         function readBlock(fileBlock, callback){
@@ -434,7 +382,7 @@ function createFileParser(fd, callback){
                         return callback(err);
                     }
 
-                    return readPBFElementFromBuffer(data, OSM_BLOB_DECODER_BY_TYPE[fileBlock.blobHeader.type], callback);
+                    return buf.readPBFElementFromBuffer(data, OSM_BLOB_DECODER_BY_TYPE[fileBlock.blobHeader.type], callback);
                 });
             });
         }
@@ -450,14 +398,14 @@ function createFileParser(fd, callback){
 }
 
 function createPathParser(opts){
-    fs.open(opts.filePath, 'r', function(err, fd){
+    reader.open(opts, function(err, fd){
         createFileParser(fd, function(err, parser){
             if(err){
                 return opts.callback(err);
             }
 
             parser.close = function(callback){
-                return fs.close(fd, callback);
+                return reader.close(fd, callback);
             };
 
             return opts.callback(null, parser);


### PR DESCRIPTION
part of #4

Suggesting to extract Node.js dependencies into separate files per module, in a `nodejs` subdirectory.

Here, functions with `fs`-specific code are extracted into `nodejs/fsReader.js`. Still need to pass the file descriptor `fd` through functions in `pbfParser.js`, but now that could just as well be an `ArrayBuffer`. Already adds `nodejs/buffer.js` because of a common dependency.
