### PR TITLE
cache decoded StringTable entries

### DIFF
--- a/lib/pbfParser.js
+++ b/lib/pbfParser.js
@@ -84,17 +84,25 @@ function readFileBlocks(fd, callback){
 }
 
 function getStringTableEntry(i){
-    var s;
+    var s, str;
 
-    s = this.s[i];
+    // decode StringTable entry only once and cache
+    if (i in this.cache) {
+        str = this.cache[i];
+    } else {
+        s = this.s[i];
 
-    // obviously someone is missinterpreting the meanding of 'offset'
-    // and 'length'. they should be named 'start' and 'end' instead.
-    return s.readUTF8StringBytes(s.length - s.offset, s.offset).string;
+        // obviously someone is missinterpreting the meanding of 'offset'
+        // and 'length'. they should be named 'start' and 'end' instead.
+        str = s.readUTF8StringBytes(s.length - s.offset, s.offset).string;
+        this.cache[i] = str;
+    }
 
+    return str;
 }
 
 function extendStringTable(st){
+    st.cache = {};
     st.getEntry = getStringTableEntry;
 }
 


### PR DESCRIPTION
I have not done extensive tests, but manual comparison of an ~950 kB PBF shows an improvement from ~1000ms to 830ms in the browser
