### PR TITLE
fix parser doesn't exist error

### DIFF
--- a/lib/defer.js
+++ b/lib/defer.js
@@ -1,0 +1,12 @@
+
+var defer = function( total, done ){
+    var c = 0;
+
+    return function(){
+        if( ++c === total ){
+            done();
+        }
+    }
+}
+
+module.exports = defer;

--- a/lib/pbfParser.js
+++ b/lib/pbfParser.js
@@ -24,6 +24,7 @@ if (typeof self !== 'undefined') {
 
 var fileFormat = require('./proto/fileformat.js');
 var blockFormat = require('./proto/osmformat.js');
+var defer = require("./defer");
 
 var BLOB_HEADER_SIZE_SIZE = 4;
 
@@ -514,29 +515,38 @@ function createPathParser(opts){
 
 function visitOSMHeaderBlock(block, opts){
     // TODO
+    opts.next();
 }
 
 function visitPrimitiveGroup(pg, opts){
     var i;
+    var total = pg.nodesView.length + pg.waysView.length + pg.relationsView.length;
+
+    opts.next = defer( total, opts.next );
 
     // visit nodes
     for(i = 0; i < pg.nodesView.length; ++i){
-        opts.node(pg.nodesView.get(i));
+        opts.node(pg.nodesView.get(i), opts.next);
+        if( opts.node.length == 1 ){ opts.next(); } // reverse compatibility
     }
 
     // visit ways
     for(i = 0; i < pg.waysView.length; ++i){
-        opts.way(pg.waysView.get(i));
+        opts.way(pg.waysView.get(i), opts.next);
+        if( opts.way.length == 1 ){ opts.next(); } // reverse compatibility
     }
 
     // visit relations
     for(i = 0; i < pg.relationsView.length; ++i){
-        opts.relation(pg.relationsView.get(i));
+        opts.relation(pg.relationsView.get(i), opts.next);
+        if( opts.relation.length == 1 ){ opts.next(); } // reverse compatibility
     }
 }
 
 function visitOSMDataBlock(block, opts){
     var i;
+
+    opts.next = defer( block.primitivegroup.length, opts.next );
 
     for(i = 0; i < block.primitivegroup.length; ++i){
         visitPrimitiveGroup(block.primitivegroup[i], opts);
@@ -591,11 +601,12 @@ function parse(opts){
                         return fail(err);
                     }
 
+                    opts.next = function(){
+                        nextFileBlockIndex += 1;
+                        visitNextBlock();
+                    }
+
                     visitBlock(fileBlock, block, opts);
-
-                    nextFileBlockIndex += 1;
-
-                    visitNextBlock();
                 });
             }
 


### PR DESCRIPTION
In the case where an `err` is returned and `parser` is `null`; we should check for the existence of `parser` before calling it.

This is currently throwing for me:

``` bash
osm-read/lib/pbfParser.js:464
                parser.close();
                       ^
TypeError: Cannot call method 'close' of undefined
    at fail (osm-read/lib/pbfParser.js:464:24)
    at Object.createPathParser.callback (osm-read/lib/pbfParser.js:470:24)
    at osm-read/lib/pbfParser.js:409:29
    at osm-read/lib/pbfParser.js:350:20
    at osm-read/lib/pbfParser.js:66:28
    at osm-read/lib/pbfParser.js:42:24
    at bytesReadFail (osm-read/lib/nodejs/fsReader.js:5:12)
    at osm-read/lib/nodejs/fsReader.js:33:20
    at Object.wrapper [as oncomplete] (fs.js:454:17)
```
