### PR TITLE
fix parser doesn't exist error

### DIFF
--- a/lib/pbfParser.js
+++ b/lib/pbfParser.js
@@ -560,7 +560,9 @@ function parse(opts){
             var nextFileBlockIndex;
 
             function fail(err){
-                parser.close();
+                if( parser ){
+                    parser.close();
+                }
 
                 return opts.error(err);
             }


### PR DESCRIPTION
In the case where an `err` is returned and `parser` is `null`; we should check for the existence of `parser` before calling it.

This is currently throwing for me:

``` bash
osm-read/lib/pbfParser.js:464
                parser.close();
                       ^
TypeError: Cannot call method 'close' of undefined
    at fail (osm-read/lib/pbfParser.js:464:24)
    at Object.createPathParser.callback (osm-read/lib/pbfParser.js:470:24)
    at osm-read/lib/pbfParser.js:409:29
    at osm-read/lib/pbfParser.js:350:20
    at osm-read/lib/pbfParser.js:66:28
    at osm-read/lib/pbfParser.js:42:24
    at bytesReadFail (osm-read/lib/nodejs/fsReader.js:5:12)
    at osm-read/lib/nodejs/fsReader.js:33:20
    at Object.wrapper [as oncomplete] (fs.js:454:17)
```
