### PR TITLE
keep tag order (no reverse iteration)

### DIFF
--- a/lib/pbfParser.js
+++ b/lib/pbfParser.js
@@ -241,11 +241,11 @@ function createNodesView(pb, pg){
 }
 
 function createTagsObject(pb, entity){
-    var tags, i, keyI, valI, key, val;
+    var tags, i, len, keyI, valI, key, val;
 
     tags = {};
 
-    for(i = 0; i < entity.keys.length; ++i){
+    for(i = 0, len = entity.keys.length; i < len; ++i){
         keyI = entity.keys[i];
         valI = entity.vals[i];
 


### PR DESCRIPTION
Iterate tags in regular instead of reverse order to keep tag ordering (where supported), e.g. pbf.html example:
old:

```
way:      {... ,"tags":{"name":"üßé€","highway":"service","access":"private"}, ...
relation: {... ,"tags":{"type":"route","route":"bus","ref":"123","network":"VVW"}, ...
```

new (order as defined in test.xml/.pbf):

```
way:      {... ,"tags":{"access":"private","highway":"service","name":"üßé€"}, ...
relation: {... ,"tags":{"network":"VVW","ref":"123","route":"bus","type":"route"}, ...
```

@marook: Was there a reason to do a reverse iteration? It's not actually wrong as object keys are not guaranteed to be returned in the order added, but they usually are, so I don't see why not to keep that order.
